### PR TITLE
Ability to customise database directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The last command will download all the databases to the GeoIP share directory.
 Set this to run once a week or so. Downloads will only happen if the remote
 file is newer than the local version.
 
+## Custom path to store maxmind database
+If access to /usr/local/share/GeoIP is unavailable, the following environment
+variable is available: MAXMIND_DB_DIR. E.g.
+
+    export MAXMIND_DB_DIR=/home/example/maxmind-db
 
 [ci-image]: https://travis-ci.org/msimerson/maxmind-geolite-mirror.svg
 [ci-url]:  https://travis-ci.org/msimerson/maxmind-geolite-mirror

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@
 if (process.env.COVERAGE) require('blanket');
 
 // where your GeoIP databases are stored
-exports.dbDir = '/usr/local/share/GeoIP/';
+exports.dbDir = process.env.MAXMIND_DB_DIR || '/usr/local/share/GeoIP/';
 
 // the download site to fetch them from
 exports.hostName = 'geolite.maxmind.com';

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "grunt-mocha-test": "^0.12.7",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",
-    "mocha-lcov-reporter": "0.0.1"
+    "mocha-lcov-reporter": "0.0.1",
+    "rewire": "^2.3.4"
   },
   "license": "MIT",
   "files": [

--- a/test/config.js
+++ b/test/config.js
@@ -1,12 +1,23 @@
 'use strict';
 
 var assert = require('assert');
+var rewire = require('rewire');
 
-var config = require('../lib/config');
+var config = rewire('../lib/config');
 
 describe('config', function () {
     it('has dbDir', function () {
         assert.ok(config.dbDir);
+    });
+
+    it('has custom dbDir', function() {
+        var expected = '/foo/bar';
+        process.env.MAXMIND_DB_DIR = expected;
+
+        config = rewire('../lib/config');
+
+        assert.equal(config.dbDir, expected);
+        delete process.env.MAXMIND_DB_DIR;
     });
 
     it('has geoIpDbs', function () {
@@ -29,4 +40,3 @@ describe('config', function () {
         assert.ok(config.urlPath);
     });
 });
-


### PR DESCRIPTION
Creating an optional `MAXMIND_DB_DIR` variable that if set overrides the default /usr/local/share/GeoIP directory for systems that don't have access to /usr/local/share.