### PR TITLE
Release 1.0.6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "dot-notation": 2,
+    "indent": [2, 4, {"SwitchCase": 1}],
+    "one-var": [2, "never"],
+    "keyword-spacing": [2, {"overrides": {
+      }}],
+    "no-trailing-spaces": [2, { "skipBlankLines": false }],
+    "no-delete-var": 2,
+    "no-label-var": 2,
+    "no-shadow": 2,
+    "no-unused-vars": [ 1, { "args": "none" }]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: node_js
 
 node_js:
-    - "0.12"
-    - "0.10"
+    - "5"
+    - "4"
+    #- iojs   No longer maintained
+    #- "0.12" Maintenance ending 2017-04-01
+    #- "0.10" Maintenance ending 2016-10-01
     #- "0.8"  Not supported by mocha
     #- "0.6"  Script works, tests don't
-    - iojs
 
-after_script:
-    - npm run coveralls
+after_success:
+    - npm install istanbul codecov.io
+    - ./node_modules/istanbul/lib/cli.js cov run_tests
+    - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,16 @@
 
+# 1.0.6 - 2016-04-05
 
     - added Contributors
+    - suppress error when attempting to delete a file that failed to download
 
-# 1.05  2015-06-23  @msimerson
+# 1.0.5 - 2015-06-23  @msimerson
 
     - enable testing on node 0.12 (remove 0.11)
     - move dev docs to DEVELOP.md
     - demote non-working badges to bottom of README
 
-#  1.04  2015-06-23  @cbanbury
+#  1.0.4 - 2015-06-23  @cbanbury
 
     - allow configurable db dir with MAXMIND_DB_DIR
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -5,20 +5,5 @@ Contributions are welcome and appreciated. Please keep in mind the following:
 
 * there are no dependencies. That's on purpose.
 * test coverage is at 100%, help keep it that way.
-* squashed PRs are the best PRs.
 
 
-### How to squash:
-
-````sh
-git remote add msimerson
-https://github.com/msimerson/maxmind-geolite-mirror.git
-git rebase -i msimerson/master
-````
-
-Then change `pick` to `s` for all but the first commit and save changes. Then
-force push the squashed branch to your repo:
-
-````sh
-git push -f origin
-````

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,20 +2,19 @@
 module.exports = function(grunt) {
 
     grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-coveralls');
     grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-eslint');
 
     // Project configuration.
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
-        jshint: {
-            options: {
-                jshintrc: true,
+        eslint: {
+            main: {
+                src: ['bin/*', 'lib/**/*.js' ]
             },
-            bin: [ 'bin/*' ],
-            lib: [ 'lib/**/*.js' ],
-            all: [ '<%= jshint.bin %>', '<%= jshint.lib %>' ],
+            test: {
+                src: ['test/**/*.js'],
+            }
         },
         mochaTest: {
             options: {
@@ -26,19 +25,8 @@ module.exports = function(grunt) {
         },
         clean: {
             dist: [ 'node_modules' ]
-        },
-        coveralls: {
-            options: {
-              // LCOV coverage file relevant to every target
-              src: 'coverage-results/lcov.info',
-              force: true
-            },
-            your_target: {
-              // Target-specific LCOV coverage file
-              src: 'coverage-results/extra-results-*.info'
-            },
-          },
+        }
     });
 
-    grunt.registerTask('default', ['jshint','mochaTest']);
+    grunt.registerTask('default', ['eslint','mochaTest']);
 };

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ These badges seem not to be as reliable, so they moved down here.
 [ci-url]:  https://travis-ci.org/msimerson/maxmind-geolite-mirror
 [dep-img]: https://david-dm.org/msimerson/maxmind-geolite-mirror.svg
 [dep-url]: https://david-dm.org/msimerson/maxmind-geolite-mirror
-[cov-img]: https://coveralls.io/repos/msimerson/maxmind-geolite-mirror/badge.svg
-[cov-url]: https://coveralls.io/r/msimerson/maxmind-geolite-mirror
+[cov-img]: https://codecov.io/github/msimerson/maxmind-geolite-mirror/coverage.svg?branch=master
+[cov-url]: https://codecov.io/github/msimerson/maxmind-geolite-mirror?branch=master
 [npm-image]: https://nodei.co/npm/maxmind-geolite-mirror.png?downloads=true&stars=true
 [npm-url]: https://nodei.co/npm/maxmind-geolite-mirror/
 [win-ci-img]: https://ci.appveyor.com/api/projects/status/1e2vtbq1ekfvvwl7/branch/master?svg=true

--- a/bin/maxmind-geolite-mirror
+++ b/bin/maxmind-geolite-mirror
@@ -5,7 +5,6 @@ if (process.env.COVERAGE) require('blanket');
 
 var fs    = require('fs');
 var http  = require('http');
-var util  = require('util');
 var zlib  = require('zlib');
 
 var config = require('../lib/config');
@@ -75,8 +74,8 @@ var download = function(dest, opts, done) {
             file.close(function (err) {
                 if (err) throw err;
                 // console.log("moved " + dest + '.tmp to ' + dest);
-                fs.rename(dest + '.tmp', dest, function (err) {
-                    if (err) throw err;
+                fs.rename(dest + '.tmp', dest, function (err2) {
+                    if (err2) throw err2;
                     console.log('saved ' + dest);
                     done();
                 });
@@ -98,7 +97,7 @@ var download = function(dest, opts, done) {
 var doOne = function (item, done) {
 
     var opts = new httpReqOpts();
-        opts.path = config.urlPath + item.remote;
+    opts.path = config.urlPath + item.remote;
 
     var dest = config.dbDir  + item.local;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxmind-geolite-mirror",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "homepage": "https://github.com/msimerson/maxmind-geolite-mirror",
   "description": "Mirror maxmind dbs from geolite.maxmind.com",
   "author": {
@@ -34,22 +34,17 @@
     "maxmind"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "coveralls": "COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "./node_modules/.bin/mocha"
   },
   "devDependencies": {
-    "blanket": "^1.1.6",
-    "contributors": "^0.5.0",
-    "coveralls": "^2.11.2",
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-coveralls": "^1.0.0",
-    "grunt-mocha-test": "^0.12.7",
-    "jshint": "^2.6.0",
-    "mocha": "^2.1.0",
-    "mocha-lcov-reporter": "0.0.1",
-    "rewire": "^2.3.4"
+    "contributors": "*",
+    "eslint": "*",
+    "grunt": "*",
+    "grunt-contrib-clean": "*",
+    "grunt-eslint": "*",
+    "grunt-mocha-test": "*",
+    "mocha": "*",
+    "rewire": "*"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
* only test on node 4 & 5
    * older versions of node still work
* replace coveralls with coverage.io
    * to reduce dev dependencies
* replace jshint with eslint