### PR TITLE
don't silently fail on the first 404

### DIFF
--- a/lib/mm-geolite-mirror.js
+++ b/lib/mm-geolite-mirror.js
@@ -102,7 +102,7 @@ function download (dest, opts, done) {
         if (res.statusCode !== 200) {
             con.error(`response code ${res.statusCode} not handled!`);
             con.error('HEADERS: ' + JSON.stringify(res.headers));
-            return;
+            return done('err: ' + res.statusCode);
         }
 
         // handle tarballs as necessary


### PR DESCRIPTION
currently if one download 404's (as `GeoIPASNumv6.dat` does), no further databases are downloaded and the application silently fails.