### PR TITLE
pass errors up to caller via cb (vs ignore or throw)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+
+## 1.1.2 - 2019-01-29
+
+- pass errors via cb (vs ignore or throw)
+- more conversion to es6 template strings
+
 ## 1.1.1 - 2019-01-09
 
 - remove geoip DBs no longer served by MM

--- a/bin/maxmind-geolite-mirror
+++ b/bin/maxmind-geolite-mirror
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 'use strict';
 
+const cons   = require('../lib/console');
 const config = require('../lib/config');
 const mirror = require('../lib/mm-geolite-mirror');
 
 if (require.main === module) {
     // check each file, in series (poor mans async.eachSeries)
-    mirror.doOne(config.geoIpDbs.shift(), function iterator () {
+    mirror.doOne(config.geoIpDbs.shift(), function iterator (err) {
+        if (err) {
+            cons.error(err)
+            if (config.geoIpDbs.length) cons.log('exiting prematurely.')
+            process.exit(1)
+        }
         if (!config.geoIpDbs.length) return;
         mirror.doOne(config.geoIpDbs.shift(), iterator);
-    });
+    })
 }

--- a/lib/mm-geolite-mirror.js
+++ b/lib/mm-geolite-mirror.js
@@ -22,7 +22,7 @@ function httpReqOpts () {
 function isRemoteNewer (dest, httpOpts, done) {
 
     if (!fs.existsSync(dest)) {
-        // con.log(dest + ' does not exist');
+        // con.log(`${dest} does not exist`);
         return done(true);
     }
 
@@ -59,10 +59,11 @@ function isRemoteNewer (dest, httpOpts, done) {
             con.error(e);
             done(false);
         });
+
     request.end();
 }
 
-function handleTarball (dest, res, callback) {
+function expandTarball (dest, res, callback) {
     let untar = null;
     try {
         untar = require('tar-stream').extract();
@@ -81,14 +82,11 @@ function handleTarball (dest, res, callback) {
             con.error(`WARNING: encountered more than one mmdb file in .tar.gz. Saving first match (${foundFile}) as ${dest}.`);
             return cb();
         }
-        else {
-            const outstream = fs.createWriteStream(`${dest}.tmp`);
-            outstream.on('finish', () => {
-                fs.rename(`${dest}.tmp`, dest, cb);
-            })
-            stream.pipe(outstream);
-            foundFile = header.name;
-        }
+
+        const outstream = fs.createWriteStream(`${dest}.tmp`);
+        outstream.on('finish', () => { fs.rename(`${dest}.tmp`, dest, cb); })
+        stream.pipe(outstream);
+        foundFile = header.name;
     })
 
     untar.on('finish', callback);
@@ -100,28 +98,27 @@ function download (dest, opts, done) {
 
     const request = http.request(opts, (res) => {
         if (res.statusCode !== 200) {
-            con.error(`response code ${res.statusCode} not handled!`);
             con.error('HEADERS: ' + JSON.stringify(res.headers));
-            return;
+            return done(`response code ${res.statusCode} not handled!`);
         }
 
         // handle tarballs as necessary
-        if (/\.tar\.gz$/.test(opts.path)) return handleTarball(dest, res, done);
+        if (/\.tar\.gz$/.test(opts.path)) return expandTarball(dest, res, done);
 
         const file = fs.createWriteStream(`${dest}.tmp`);
         res.pipe(zlib.createGunzip()).pipe(file);
         file.on('finish', () => {
-            // con.log("wrote to file " + dest + '.tmp');
+            // con.log(`wrote to file ${dest}.tmp`);
             file.close((err) => {
-                if (err) throw err;
-                // con.log("moved " + dest + '.tmp to ' + dest);
+                if (err) return done(err);
+                // con.log(`moved ${dest}.tmp to ${dest}`);
                 fs.rename(`${dest}.tmp`, dest, (err2) => {
-                    if (err2) throw err2;
+                    if (err2) return done(err2);
                     con.log(`saved ${dest}`);
                     done();
-                });
-            });
-        });
+                })
+            })
+        })
     })
         .on('error', (e) => {
             con.error(e);
@@ -129,7 +126,7 @@ function download (dest, opts, done) {
             // unlikely the file exists. In the general case, this
             // callback catches the error and...ignores it.
             })
-            if (done) done('err: ' + e.message);
+            done(`err: ${e.message}`);
         })
 
     request.end();
@@ -138,9 +135,8 @@ function download (dest, opts, done) {
 function doOne (item, done) {
 
     const opts = new httpReqOpts();
-    opts.path = config.urlPath + item.remote;
-
-    const dest = config.dbDir  + item.local;
+    opts.path  = config.urlPath + item.remote;
+    const dest = config.dbDir   + item.local;
 
     isRemoteNewer(dest, opts, (shouldGet) => {
         if (!shouldGet) return done();
@@ -156,4 +152,4 @@ module.exports = {
     download: download,
     isRemoteNewer: isRemoteNewer,
     doOne: doOne
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxmind-geolite-mirror",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/msimerson/maxmind-geolite-mirror",
   "description": "Mirror maxmind dbs from geolite.maxmind.com",
   "author": {


### PR DESCRIPTION
- pass errors up to caller via cb (vs ignore or throw)
- more conversion to es6 template strings
- version bump

fixes #23 