### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 14, 16 ]
+        node-version: [ 16, 18, 20 ]
       fail-fast: false
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Use Node.js 14
       uses: actions/setup-node@master
       with:
-        node-version: 14
+        node-version: 18
 
     - run: |
         npm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,15 +8,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 16.x ]
+        node-version: [ 18 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Use Node.js ${{ matrix.node-version }}
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [ push, pull_request ]
 
+env:
+  CI: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -27,5 +30,3 @@ jobs:
       - name: Lint using eslint
         run: npm run lint
 
-        env:
-          CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - master
+    paths:
+      - package.json
 
 env:
-  node_version: 14
+  node_version: 18
 
 jobs:
 
@@ -16,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup node.js ${{ env.node_version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
           node-version: ${{ env.node_version }}
@@ -36,7 +38,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # - name: GitHub Release
-      #   uses: justincy/github-action-npm-release@2.0.1
-      #   id: release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".release"]
+	path = .release
+	url = git@github.com:msimerson/.release.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 
+### Unreleased
+
+
 ### 1.1.8 - 2022-03-14
 
 - update CI images (goes with 1.1.7)
@@ -80,3 +83,4 @@
 ### 1.0.4 - 2015-06-23  @cbanbury
 
 - allow configurable db dir with MAXMIND_DB_DIR
+[1.2.0]: https://github.com/msimerson/maxmind-geolite-mirror/releases/tag/1.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 
 ### Unreleased
 
+### 1.2.0 - 2023-06-20
+
+- bump dep versions to latest
+- ci: add .release
+- deps(contributors): removed, vuln, not maintained
+
 
 ### 1.1.8 - 2022-03-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxmind-geolite-mirror",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "homepage": "https://github.com/msimerson/maxmind-geolite-mirror",
   "description": "Mirror maxmind dbs from geolite.maxmind.com",
   "author": {
@@ -43,11 +43,11 @@
     "versions": "npx dependency-version-checker check"
   },
   "devDependencies": {
-    "contributors": "*",
-    "eslint": ">=7",
-    "mocha": "*",
-    "rewire": "*",
-    "tmp": "*"
+    "contributors": "0.5.1",
+    "eslint": "^8.43.0",
+    "mocha": "^10.2.0",
+    "rewire": "^6.0.0",
+    "tmp": "^0.2.1"
   },
   "license": "MIT",
   "files": [
@@ -56,6 +56,6 @@
     "test"
   ],
   "optionalDependencies": {
-    "tar-stream": "^2.1.0"
+    "tar-stream": "^3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "maxmind-geolite-mirror": "./bin/maxmind-geolite-mirror"
   },
   "engines": {
-    "node": ">= v12.0.0"
+    "node": ">= v14.0.0"
   },
   "main": "bin/maxmind-geolite-mirror",
   "keywords": [
@@ -43,7 +43,6 @@
     "versions": "npx dependency-version-checker check"
   },
   "devDependencies": {
-    "contributors": "0.5.1",
     "eslint": "^8.43.0",
     "mocha": "^10.2.0",
     "rewire": "^6.0.0",


### PR DESCRIPTION
- bump dep versions to latest
- ci: add .release
- deps(contributors): removed, vuln, not maintained
